### PR TITLE
Adding TogetherJs patch commit first   currentUrl in case of null

### DIFF
--- a/togetherjs/session.js
+++ b/togetherjs/session.js
@@ -131,7 +131,7 @@ define(["require", "util", "channels", "jquery", "storage"], function (require, 
         msg.peer.updateFromHello(msg);
       }
       if (msg.peer) {
-        msg.sameUrl = msg.peer.url == currentUrl;
+        msg.sameUrl = msg.peer.url == session.currentUrl();
         if (!msg.peer.isSelf) {
           msg.peer.updateMessageDate(msg);
         }


### PR DESCRIPTION
In case where hash separated url are considered separate then when hello is received currentUrl is not updated with new value , in that case use session.currentUrl()